### PR TITLE
Stop setting global logging level in metax_api.py

### DIFF
--- a/ckanext/etsin/metax_api.py
+++ b/ckanext/etsin/metax_api.py
@@ -3,14 +3,14 @@ import requests
 import sys
 from pprint import pprint
 
-# Setup http logging for debug purposes
 import logging
-logging.basicConfig()
-logging.getLogger().setLevel(logging.DEBUG)
-requests_log = logging.getLogger("requests.packages.urllib3")
-requests_log.setLevel(logging.DEBUG)
-requests_log.propagate = True
+log = logging.getLogger(__name__)
 
+# # Uncomment to setup http logging for debug purposes (note: will log requests
+# # made from other files as well)
+# requests_log = logging.getLogger("requests.packages.urllib3")
+# requests_log.setLevel(logging.DEBUG)
+# requests_log.propagate = True
 
 # TODO: All these functions must log all the API calls we make and all the responses.
 


### PR DESCRIPTION
This fixes spamming of blocking_request in the ckan log